### PR TITLE
Performance improvements from peteraisher/fuse-swift

### DIFF
--- a/Fuse/Classes/String+Fuse.swift
+++ b/Fuse/Classes/String+Fuse.swift
@@ -31,7 +31,7 @@ extension String {
             return nil
         }
         
-        if self.startIndex.encodedOffset + position > self.endIndex.encodedOffset {
+        if self.count < position {
             return nil
         }
         


### PR DESCRIPTION
FuseUtilities.swift:
- added a version of calculateScore which uses length, to avoid repeated calls to String.count, which is O(n) for a string of length n.
- calculatePatternAlphabet: eliminated unnecessary loop to zero mask by using nil coalescing instead.
- calculatePatternAlphabet: eliminated unnecessary calls to String.index(_, offsetBy: n), which is O(n), by instead looping through pattern.enumerated()
- findRanges: eliminated unnecessary variable `end` and unnecessary subtraction of one, using `..<` instead of `...` operator.
Fuse.swift:
- changed all calls to calculateScore to use precalculated string length (see FuseUtilities.swift)
- calculate text.count once
- eliminate unnecessary Double/Int conversions in calculation of binMid
- avoid calls to text.char(at:), which is O(n+j) for offset of j in string length n, instead calculate index of currentLocation once, then apply String.index(before:) once per loop iteration, which is O(1).